### PR TITLE
Alt Text Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Neoquiz Changelog
+
+## 1.1.0 (2023-09-13)
+
+- Added support for `altText` field on Questions, Results, and QuizMetaData.
+- Display altText fields in Neoquiz UI.
+
+## 1.0.0 (2022-07-18)
+
+- Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neoquiz",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Library for making fun quizzes for your personal website!",
   "main": "index.js",
   "scripts": {

--- a/src/alttext.ts
+++ b/src/alttext.ts
@@ -1,0 +1,27 @@
+import { QuizMetaData } from './quizmetadata';
+import { Question } from './question';
+import { Result } from './result';
+
+interface HasAltText {
+  image?: string;
+  altText?: string;
+}
+
+function getAltText(item: HasAltText, fallback: string): string {
+  if (!item.image) {
+    return '';
+  }
+  return item.altText ?? fallback;
+}
+
+export function getQuestionAltText(question: Question): string {
+  return getAltText(question, question.title);
+}
+
+export function getResultAltText(result: Result): string {
+  return getAltText(result, result.name);
+}
+
+export function getQuizMetaAltText(quiz: QuizMetaData): string {
+  return getAltText(quiz, quiz.title);
+}

--- a/src/neoquiz-ui.ts
+++ b/src/neoquiz-ui.ts
@@ -1,5 +1,6 @@
 import { NeoQuiz, QuizState } from './neoquiz';
 import { QuestionAnswer } from './question';
+import { getQuestionAltText, getResultAltText } from './alttext';
 
 import { shuffle } from './util';
 
@@ -43,6 +44,7 @@ export class NeoQuizUi {
     if (this.quiz.image) {
       this.appendElement('img', undefined, {
         src: this.quiz.image,
+        alt: this.quiz.altText,
       });
       if (this.quiz.imageAttribution) {
         const attribution = this.appendElement('span', undefined, {}, [
@@ -69,6 +71,7 @@ export class NeoQuizUi {
     if (this.quiz.currentQuestion.image) {
       this.appendElement('img', undefined, {
         src: this.quiz.currentQuestion.image,
+        alt: getQuestionAltText(this.quiz.currentQuestion),
       });
       if (this.quiz.currentQuestion.imageAttribution) {
         const attribution = this.appendElement('span', undefined, {}, [
@@ -168,6 +171,7 @@ export class NeoQuizUi {
         undefined,
         {
           src: this.quiz.result.image,
+          alt: getResultAltText(this.quiz.result),
         },
         [],
         resultsContainer
@@ -187,6 +191,7 @@ export class NeoQuizUi {
         // Resetting src is going to trigger an infinite loop of event calls. Let's delete the event listener by cloning this image and replacing it with an event-less clone.
         const eventlessImg = document.createElement('img');
         eventlessImg.src = img.src;
+        eventlessImg.alt = img.alt;
         img.replaceWith(eventlessImg);
         shareHTML.innerText = resultsContainer.outerHTML;
       });

--- a/src/neoquiz.ts
+++ b/src/neoquiz.ts
@@ -1,16 +1,9 @@
-import { url } from 'inspector';
+import { QuizMetaData } from './quizmetadata';
 import { NeoQuizUi } from './neoquiz-ui';
 import { Question, QuestionAnswer } from './question';
 import { Result, ResultStrategy } from './result';
 import { SimpleResultStrategy } from './simpleresults';
-
-export interface QuizMetaData {
-  title: string;
-  description: string;
-  image?: string;
-  imageAttribution?: string;
-  startText?: string;
-}
+import { getQuizMetaAltText } from './alttext';
 
 export interface QuizData {
   questions: Question[];
@@ -78,6 +71,13 @@ export class NeoQuiz {
 
   get imageAttribution(): string | undefined {
     return this.metadata?.imageAttribution;
+  }
+
+  get altText(): string {
+    if (this.metadata) {
+      return getQuizMetaAltText(this.metadata);
+    }
+    return '';
   }
 
   get uiStartText(): string {

--- a/src/question.ts
+++ b/src/question.ts
@@ -5,6 +5,7 @@ export interface Question {
   image?: string;
   imageAttribution?: string;
   shuffleAnswers?: boolean;
+  altText?: string;
 }
 
 export interface QuestionAnswer {

--- a/src/quizmetadata.ts
+++ b/src/quizmetadata.ts
@@ -1,0 +1,8 @@
+export interface QuizMetaData {
+  title: string;
+  description: string;
+  image?: string;
+  imageAttribution?: string;
+  altText?: string;
+  startText?: string;
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -4,6 +4,7 @@ export interface Result {
   description?: string;
   image?: string;
   imageAttribution?: string;
+  altText?: string;
 }
 
 // what is this, an enterprise Java application????

--- a/test/alttext.spec.ts
+++ b/test/alttext.spec.ts
@@ -1,0 +1,131 @@
+import { Question } from '../src/question';
+import { Result } from '../src/result';
+import { QuizMetaData } from '../src/quizmetadata';
+import {
+  getQuestionAltText,
+  getQuizMetaAltText,
+  getResultAltText,
+} from '../src/alttext';
+import { NeoQuiz } from '../src/neoquiz';
+
+describe('Alt Text', () => {
+  describe('Questions', () => {
+    it('should use question title for image alt text as fallback', () => {
+      expectAltText(
+        {
+          title: 'Question Title',
+          answers: ['answer'],
+          image: 'potato.jpg',
+        },
+        'Question Title'
+      );
+    });
+    it('should have no alt text if there is no image', () => {
+      expectAltText(
+        {
+          title: 'Question Title',
+          answers: ['answer'],
+        },
+        ''
+      );
+    });
+    it('should use alt text field if it exists', () => {
+      expectAltText(
+        {
+          title: 'Question Title',
+          answers: ['answer'],
+          image: 'potato.jpg',
+          altText: 'A potato',
+        },
+        'A potato'
+      );
+    });
+    function expectAltText(question: Question, expected: string) {
+      expect(getQuestionAltText(question)).toBe(expected);
+    }
+  });
+  describe('Results', () => {
+    it('should use result name for image alt text as fallback', () => {
+      expectAltText(
+        {
+          id: 'default',
+          name: 'Result Title',
+          image: 'potato.jpg',
+        },
+        'Result Title'
+      );
+    });
+    it('should have no alt text if there is no image', () => {
+      expectAltText(
+        {
+          id: 'default',
+          name: 'Result Title',
+        },
+        ''
+      );
+    });
+    it('should use alt text field if it exists', () => {
+      expectAltText(
+        {
+          id: 'default',
+          name: 'Result Title',
+          image: 'potato.jpg',
+          altText: 'A potato',
+        },
+        'A potato'
+      );
+    });
+    function expectAltText(result: Result, expected: string) {
+      expect(getResultAltText(result)).toBe(expected);
+    }
+  });
+  describe('Quiz Metadata', () => {
+    it('should use quiz name for image alt text as fallback', () => {
+      expectAltText(
+        {
+          title: 'Test Quiz',
+          description: 'potato quiz',
+          image: 'potato.jpg',
+        },
+        'Test Quiz'
+      );
+    });
+    it('should have no alt text if there is no image', () => {
+      expectAltText(
+        {
+          title: 'Test Quiz',
+          description: 'potato quiz',
+        },
+        ''
+      );
+    });
+    it('should use alt text field if it exists', () => {
+      expectAltText(
+        {
+          title: 'Test Quiz',
+          description: 'potato quiz',
+          image: 'potato.jpg',
+          altText: 'A potato',
+        },
+        'A potato'
+      );
+    });
+    it('can access it on NeoQuiz object', () => {
+      const quiz = new NeoQuiz();
+      quiz.addMetaData({
+        title: 'Test Quiz',
+        description: 'potato quiz',
+        image: 'potato.jpg',
+        altText: 'A potato',
+      });
+      expect(quiz.altText).toBe('A potato');
+    });
+    it('will return with an empty string on undefined metadata', () => {
+      const quiz = new NeoQuiz();
+      expect(quiz.altText).toBe('');
+    });
+    function expectAltText(result: QuizMetaData, expected: string) {
+      expect(getQuizMetaAltText(result)).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
Add support for `altText` fields on Neoquiz objects with images (QuizMetaData, Question, Result). Display this alt text in the UI.